### PR TITLE
Remove unnecessary RunAtLoad key in plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,62 @@
 # brewupdate #
 
-brewupdate is a [launchd agent][launchd] to update [homebrew][homebrew] formulae automatically every 5 days at 11 AM (local time).
+brewupdate is a [launchd agent][launchd] to update [homebrew][homebrew] formulae automatically every 7 days at 11 AM (local time).
 
-brewupdate will `brew update`, `brew upgrade`, and `brew doctor` so you may want to adjust this behaviour given an upgrade may break something dependent on a certain version.
+## IMPORTANT!
+
+brewupdate will `brew update`, `brew upgrade`, and `brew doctor` so you may want to adjust this behaviour inside `brewupdate.sh` given an upgrade may break something dependent on a certain version.
 
 ## How to Install or Upgrade ##
 Run the following command in the terminal:
 
-```sh
-curl -L https://github.com/cgswong/brewupdate/raw/master/brewupdate-install.sh | bash
+```shell
+$ curl -L https://github.com/heitortsergent/brewupdate/raw/master/brewupdate-install.sh | bash
 ```
 
 ### Manual installation ###
-To manually install `brewupdate`, copy the plist to `~/Library/LaunchAgents` and run the command `launchctl load ~/Library/LaunchAgents/net.brewupdate.agent.plist` to load the LaunchAgent into the launchd manager.
+
+To manually install `brewupdate`:
+
+Copy `brewupdate.sh` to your `/usr/local/bin` folder, then the plist to `~/Library/LaunchAgents` and run the command `launchctl load ~/Library/LaunchAgents/net.brewupdate.agent.plist` to load the LaunchAgent into the launchd manager.
 
 Here is a quick rundown:
-```
-> mkdir ~/Library/LaunchAgents
-> cp net.brewupdate.agent.plist ~/Library/LaunchAgents
-> launchctl load ~/Library/LaunchAgents/net.brewupdate.agent.plist
+
+```shell
+# install terminal-notifier to get a nice user notification when the script runs
+$ brew install terminal-notifier
+
+# download repo and copy files to correct folders
+$ git clone https://github.com/heitortsergent/brewupdate.git && cd brewupdate
+$ cp brewupdate.sh /usr/local/bin
+$ mkdir ~/Library/LaunchAgents
+$ cp net.brewupdate.agent.plist ~/Library/LaunchAgents
+
+# add log paths to .plist file
+$ defaults write ~/Library/LaunchAgents/net.brewupdate.agent.plist StandardOutPath $HOME/Library/Logs/Homebrew/brewupdate/brewupdate.log && defaults write ~/Library/LaunchAgents/net.brewupdate.agent.plist StandardErrorPath $HOME/Library/Logs/Homebrew/brewupdate/brewupdate-error.log
+$ mkdir -p $HOME/Library/Logs/Homebrew/brewupdate
+
+# load the LaunchAgent
+$ launchctl load ~/Library/LaunchAgents/net.brewupdate.agent.plist
 ```
 
 ### Manual upgrade ###
-If you installed a previous version of brewupdate, unload the loaded LaunchAgent, copy the new agent to `~/Library/LaunchAgents`, and load the copied LaunchAgent.
+
+If you installed a previous version of brewupdate, unload the loaded LaunchAgent, copy the new `brewupdate.sh` and/or the new agent to `~/Library/LaunchAgents`, and load the copied LaunchAgent.
 
 Here is a quick rundown:
+
 ```
-> launchctl unload ~/Library/LaunchAgents/net.brewupdate.agent.plist
-> cp net.brewupdate.agent.plist ~/Library/LaunchAgents
-> launchctl load ~/Library/LaunchAgents/net.brewupdate.agent.plist
+$ launchctl unload ~/Library/LaunchAgents/net.brewupdate.agent.plist
+$ cp brewupdate.sh /usr/local/bin
+$ cp net.brewupdate.agent.plist ~/Library/LaunchAgents
+$ launchctl load ~/Library/LaunchAgents/net.brewupdate.agent.plist
 ```
 
 ## … and where do I see what's updated? ##
+
 Since OS X 10.8, [Apple removed the redirection][apple-removed-redirection] of `stdout` and `stderr` to `system.log`.
 
-Use the search filter <code>net.brewupdate.agent</code> on "All Messages" to display the list of new and updated formulae.
+When the script runs, it'll show a notification using the [terminal-notifier][terminal-notifier] command-line tool. The logs are being kept inside `$HOME/Library/Logs/Homebrew/brewupdate/brewupdate.log` and errors inside `$HOME/Library/Logs/Homebrew/brewupdate/brewupdate-error.log`. You can change that by editing the `StandardOutPath` and `StandardErrorPath` properties inside the `net.brewupdate.agent.plist` file (don't forget to unload and load after making the changes).
 
 ## License
 
@@ -43,4 +65,5 @@ Code is under the [BSD 2-Clause license][license].
 [launchd]: http://developer.apple.com/library/mac/#technotes/tn2083/_index.html
 [homebrew]: https://github.com/mxcl/homebrew/
 [apple-removed-redirection]: http://stackoverflow.com/a/15655471/1712728
+[terminal-notifier]: https://github.com/alloy/terminal-notifier
 [license]: https://github.com/cgswong/brewupdate/tree/master/LICENSE.txt

--- a/brewupdate-install.sh
+++ b/brewupdate-install.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-BIN="/usr/local/bin"
+UPDATE_SCRIPT="/usr/local/bin/brewupdate.sh"
 AGENTS="$HOME/Library/LaunchAgents"
 PLIST="$AGENTS/net.brewupdate.agent.plist"
 REPO=${REPO:-heitortsergent}
@@ -33,8 +33,8 @@ if [ "$1" == "uninstall" ]; then
   fi
 fi
 
-curl -L "$REMOTE_SCRIPT" >| "$BIN"
-if [ -f "$BIN" ]; then
+curl -L "$REMOTE_SCRIPT" >| "$UPDATE_SCRIPT"
+if [ -f "$UPDATE_SCRIPT" ]; then
   echo "Downloaded brewupdate.sh"
 else
   echo "Failed downloading brewupdate.sh"

--- a/brewupdate-install.sh
+++ b/brewupdate-install.sh
@@ -12,11 +12,14 @@
 
 set -e
 
+BIN="/usr/local/bin"
 AGENTS="$HOME/Library/LaunchAgents"
 PLIST="$AGENTS/net.brewupdate.agent.plist"
-REPO=${REPO:-cgswong}
+REPO=${REPO:-heitortsergent}
 BRANCH=${BRANCH:-master}
-REMOTE="https://github.com/$REPO/brewupdate/raw/$BRANCH/net.brewupdate.agent.plist"
+REMOTE="https://github.com/$REPO/brewupdate/raw/$BRANCH"
+REMOTE_PLIST="$REMOTE/net.brewupdate.agent.plist"
+REMOTE_SCRIPT="$REMOTE/brewupdate.sh"
 
 [ -f "$PLIST" ] && launchctl unload "$PLIST"
 if [ "$1" == "uninstall" ]; then
@@ -30,12 +33,21 @@ if [ "$1" == "uninstall" ]; then
   fi
 fi
 
-curl -L "$REMOTE" >| "$PLIST"
+curl -L "$REMOTE_SCRIPT" >| "$BIN"
+if [ -f "$BIN" ]; then
+  echo "Downloaded brewupdate.sh"
+else
+  echo "Failed downloading brewupdate.sh"
+  exit 1
+fi
+
+curl -L "$REMOTE_PLIST" >| "$PLIST"
 [ -f "$PLIST" ] && launchctl load "$PLIST"
 if [ $? -eq 0 ]; then
   echo "Loaded brewupdate."
-  exit 0
 else
   echo "Failed loading brewupdate!!"
   exit 1
 fi
+
+exit 0

--- a/brewupdate-install.sh
+++ b/brewupdate-install.sh
@@ -50,4 +50,7 @@ else
   exit 1
 fi
 
+brew install terminal-notifier
+echo "Installed terminal-notifier."
+
 exit 0

--- a/brewupdate-install.sh
+++ b/brewupdate-install.sh
@@ -53,4 +53,11 @@ fi
 brew install terminal-notifier
 echo "Installed terminal-notifier."
 
+## create log folder
+mkdir -p $HOME/Library/Logs/Homebrew/brewupdate
+
+## add StandardOutPath and StandardErrorPath to plist
+defaults write "$PLIST" StandardOutPath $HOME/Library/Logs/Homebrew/brewupdate/brewupdate.log
+defaults write "$PLIST" StandardErrorPath $HOME/Library/Logs/Homebrew/brewupdate/brewupdate-error.log
+
 exit 0

--- a/brewupdate.sh
+++ b/brewupdate.sh
@@ -15,5 +15,6 @@ set -e
  
 ##NAME=$(basename $0)
 ##export PATH=/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-   
-(brew update && brew upgrade brew-cask && brew upgrade && brew cleanup && brew cask cleanup && brew doctor)
+
+terminal-notifier -title 'Homebrew' -message 'Updating and upgrading'
+(brew update && brew upgrade && brew cleanup && brew cask cleanup && brew doctor)

--- a/net.brewupdate.agent.plist
+++ b/net.brewupdate.agent.plist
@@ -15,8 +15,6 @@
   </dict>
   <key>Program</key>
   <string>/usr/local/bin/brewupdate.sh</string>
-  <key>RunAtLoad</key>
-  <false/>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>

--- a/net.brewupdate.agent.plist
+++ b/net.brewupdate.agent.plist
@@ -22,7 +22,7 @@
     <key>Minute</key>
     <integer>0</integer>
     <key>Weekday</key>
-    <integer>5</integer>
+    <integer>7</integer>
   </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Default for RunAtLoad is false according to docs: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/launchd.plist.5.html#//apple_ref/doc/man/5/launchd.plist